### PR TITLE
enable "--json" option

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -49,7 +49,11 @@ runner.go(function (err, results) {
 		(err.message || err.toString()).split('\n').forEach(function (line) { logger['tio2-error'](line); });
 	} else {
 		JSON.stringify(results, null, '\t').split('\n').forEach(function (line) {
-			logger['tio2-result'](line);
+            if (program.json) {
+                console.log(line);
+            } else {
+                logger['tio2-result'](line);
+            }
 		});
 	}
 	logger.tio2('Finished in %s', appc.time.prettyDiff(startTime, Date.now()).cyan);

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -49,11 +49,11 @@ runner.go(function (err, results) {
 		(err.message || err.toString()).split('\n').forEach(function (line) { logger['tio2-error'](line); });
 	} else {
 		JSON.stringify(results, null, '\t').split('\n').forEach(function (line) {
-            if (program.json) {
-                console.log(line);
-            } else {
-                logger['tio2-result'](line);
-            }
+			if (program.json) {
+				console.log(line);
+			} else {
+				logger['tio2-result'](line);
+			}
 		});
 	}
 	logger.tio2('Finished in %s', appc.time.prettyDiff(startTime, Date.now()).cyan);


### PR DESCRIPTION
Now, "--json" option dose any work.
Show test results as pure JSON format without timestamp and log level if "--json" option is true.