### PR TITLE
UpdateUpdate test marker to a generic string

### DIFF
--- a/example/harness/Resources/app.js
+++ b/example/harness/Resources/app.js
@@ -76,7 +76,7 @@ var osname = Ti.Platform.osname;
 				version: Ti.version
 			}
 		}, null, '\t');
-		Ti.API.info('!TI_MOCHA_RESULTS_START!');
+		Ti.API.info('!TEST_RESULTS_START!');
 		if(osname == 'android') {
 			// Issue 1) Android's logcat has a max limit of around 4000 characters.
 			// When the results are more than 4000 characters, the json is truncated.
@@ -96,6 +96,6 @@ var osname = Ti.Platform.osname;
 		} else {
 			Ti.API.info(jsonResults);
 		}
-		Ti.API.info('!TI_MOCHA_RESULTS_STOP!');
+		Ti.API.info('!TEST_RESULTS_STOP!');
 	});
 })();

--- a/lib/suite.js
+++ b/lib/suite.js
@@ -52,6 +52,10 @@ function Suite(name, suiteDir, runner) {
 
 	this.passed = 0;
 	this.failed = 0;
+
+	this.tiTestStartMarker = '!TEST_RESULTS_START!';
+	this.tiTestStopMarker = '!TEST_RESULTS_STOP!';
+
 }
 
 /**
@@ -569,13 +573,13 @@ Suite.prototype.runApp = function runApp(next) {
 
 			/**
 			 * Watch
-			 * @param  {Object} line - ?
+			 * @param  {String} line - iOS simulator output
 			 */
 			var watch = function (line) {
 				line = line.replace(logLevelRegExp, '');
-				if (line === '!TI_MOCHA_RESULTS_START!') {
+				if (line === self.tiTestStartMarker) {
 					inTiMochaResult = true;
-				} else if (inTiMochaResult && line === '!TI_MOCHA_RESULTS_STOP!') {
+				} else if (inTiMochaResult && line === self.tiTestStopMarker) {
 					emitter.removeListener('log', watch);
 					emitter.removeListener('logFile', watch);
 					ioslib.simulator.stop(simHandle, function () {
@@ -594,6 +598,7 @@ Suite.prototype.runApp = function runApp(next) {
 			emitter = ioslib.simulator.launch(null, {
 					appPath: this.appDir,
 					hide: true,
+					bypassCache: true,
 					logFilename: this.tiapp.guid + '.log'
 				})
 				.on('launched', function (sh) {
@@ -613,16 +618,16 @@ Suite.prototype.runApp = function runApp(next) {
 
 			emitter = ioslib.device.install(this.deviceInfo.udid, appPath, this.tiapp.id)
 				.on('installed', function (line) {
-					console.log(appName + ' installed, but cannot be launched automatically!!!');
+					logger['tio2-warn'](appName + ' installed, but cannot be launched automatically!!!');
 				})
 				.on('app-started', function (line) {
-					console.log('-- app-started');
+					logger['tio2-debug']('-- app-started');
 				})
 				.on('log', function (line) {
 					line = line.replace(logLevelRegExp, '');
-					if (line === '!TI_MOCHA_RESULTS_START!') {
+					if (line === self.tiTestStartMarker) {
 						inTiMochaResult = true;
-					} else if (inTiMochaResult && line === '!TI_MOCHA_RESULTS_STOP!') {
+					} else if (inTiMochaResult && line === self.tiTestStopMarker) {
 						emitter.removeListener('log', watch);
 						emitter.removeListener('logFile', watch);
 						try {
@@ -636,8 +641,8 @@ Suite.prototype.runApp = function runApp(next) {
 					}
 				})
 				.on('app-quit', function (line) {
-					console.log('-- app-quit');
-					console.log(data);
+					logger['tio2-debug']('-- app-quit');
+					logger['tio2-debug'](data);
 				});
 		}
 		return;
@@ -659,9 +664,9 @@ Suite.prototype.runApp = function runApp(next) {
 
 		var tiResults = "";
 		function infoParser(line) {
-			if (line.indexOf('!TI_MOCHA_RESULTS_START!')>= 0){
+			if (line.indexOf(self.tiTestStartMarker) >= 0){
 				inTiMochaResult = true;
-			} else if (inTiMochaResult && (line.indexOf('!TI_MOCHA_RESULTS_STOP!')>= 0)) {
+			} else if (inTiMochaResult && (line.indexOf(self.tiTestStopMarker) >= 0)) {
 				// Closing application in device
 				clearTimeout(timeoutClock);
 				inTiMochaResult = false;
@@ -688,14 +693,14 @@ Suite.prototype.runApp = function runApp(next) {
 		}
 
 		function androidLogger(label, message) {
-				if(label == 'info') {
-					infoParser(message);
-				}
+			if(label == 'info') {
+				infoParser(message);
+			}
 		}
 		// Timeout in case of Android crash
 		timeoutClock = setTimeout(function() {
-		  logger['tio2-debug']("Timeout! Skipping to next Suite.");
-		  next(new Error('Test Timeout!'));
+			logger['tio2-debug']("Timeout! Skipping to next Suite.");
+			next(new Error('Test Timeout!'));
 		}, this.suiteTimeout);
 
 		logger.tio2('Launching Android app on %s', target.cyan);
@@ -713,7 +718,6 @@ Suite.prototype.runApp = function runApp(next) {
 
 		return;
 	}
-
 
 	// unsupported platform
 	next(new Error(sprintf('Unsupported platform "%s"', this.platform)));


### PR DESCRIPTION
1. Changed marker text to be more generic
2. Set *bypassCache* to *true* when calling *ioslib.simulator.launch*, (or we could also update ioslib to not removing simulators from cached list)

To run [titanium_mobile_tests](https://github.com/feons/titanium_mobile_tests) on ios:
```
cd titanium_mobile_tests
tio2 . -p ios -s 3.5.0.GA
```
Tests for *stream* and *xml* crashes on 3.5.1.GA but works fine for 3.4.1.GA and 3.5.0.GA respectively.
