### PR TITLE
enable -i option to set ios version

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -82,7 +82,7 @@ function Runner(opts) {
 	this.sdkVersion = opts.sdk || '3.5.1.GA';
 	this.platform = (opts.platform || '').toLowerCase();
 	/^(?:iphone|ipad)$/.test(this.platform) && (this.platform = 'ios');
-	//this.iosVersion = opts.iosVersion || '7.1';
+	this.iosVersion = opts.iosVersion || '8.1';
 	this.androidArch = opts.androidArch || 'arm';
 	//suiteTimeout default is 10 mins
 	this.suiteTimeout = opts.suiteTimeout || 10 * 60 * 1000;

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -82,7 +82,7 @@ function Runner(opts) {
 	this.sdkVersion = opts.sdk || '3.5.1.GA';
 	this.platform = (opts.platform || '').toLowerCase();
 	/^(?:iphone|ipad)$/.test(this.platform) && (this.platform = 'ios');
-	this.iosVersion = opts.iosVersion || '8.1';
+	this.iosVersion = opts.iosVersion;
 	this.androidArch = opts.androidArch || 'arm';
 	//suiteTimeout default is 10 mins
 	this.suiteTimeout = opts.suiteTimeout || 10 * 60 * 1000;


### PR DESCRIPTION
To change ios version used to build test suites. 
Usage:
```
tio2 example -p ios -i 7.1
tio2 example -p ios --ios-version 7.1
```